### PR TITLE
Add option to listen without TLS.

### DIFF
--- a/cmd/moroz/main.go
+++ b/cmd/moroz/main.go
@@ -56,7 +56,7 @@ func main() {
 		flEvents    = flag.String("event-logfile", envString("MOROZ_EVENTLOG_FILE", "/tmp/santa_events"), "path to file for saving uploaded events")
 		flVersion   = flag.Bool("version", false, "print version information")
 		flHTTPDebug = flag.Bool("http-debug", false, "enable debug for http(dumps full request)")
-		flNoTLS     = flag.Bool("tls-handled-elsewhere", false, "I promise I terminated TLS elsewhere")
+		flUseTLS    = flag.Bool("use-tls", true, "I promise I terminated TLS elsewhere when changing this")
 	)
 	flag.Parse()
 
@@ -65,7 +65,7 @@ func main() {
 		return
 	}
 
-	if _, err := os.Stat(*flTLSCert); !*flNoTLS && os.IsNotExist(err) {
+	if _, err := os.Stat(*flTLSCert); *flUseTLS && os.IsNotExist(err) {
 		fmt.Println(openSSLBash)
 		os.Exit(2)
 	}
@@ -102,13 +102,13 @@ func main() {
 
 	go func() { fmt.Println("started server") }()
 
-	if *flNoTLS {
-		stdlog.Fatal(http.ListenAndServe(*flAddr, h))
-	} else {
+	if *flUseTLS {
 		stdlog.Fatal(http.ListenAndServeTLS(*flAddr,
 			*flTLSCert,
 			*flTLSKey,
 			h))
+	} else {
+		stdlog.Fatal(http.ListenAndServe(*flAddr, h))
 	}
 }
 


### PR DESCRIPTION
This adds a single extra flag that switches to listening over plain HTTP for cases where Moroz is running behind a TLS-terminating frontend, such as a load balancer.

If you're reading this from the far future: please don't use this unless you really do handle TLS in front of Moroz.