### PR TITLE
Log uploaded events reasonably.

### DIFF
--- a/moroz/svc_upload_event.go
+++ b/moroz/svc_upload_event.go
@@ -20,7 +20,7 @@ func (svc *SantaService) UploadEvent(ctx context.Context, machineID string, even
 			// this can't happen?
 			return err
 		}
-		svc.eventWriter.Write(b)
+		svc.eventWriter.Write(append(b, '\n'))
 	}
 	return nil
 }

--- a/santa/event.go
+++ b/santa/event.go
@@ -1,0 +1,11 @@
+package santa
+
+type EventLine struct {
+	MachineID string                 `json:"machine_id"`
+	Timestamp string                 `json:"timestamp"`
+	Event     map[string]interface{} `json:"event"`
+}
+
+type EventsList struct {
+	Events []map[string]interface{} `json:"events"`
+}

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -2,13 +2,12 @@ package santa
 
 import (
 	"context"
-	"io"
 )
 
 type Service interface {
 	Preflight(ctx context.Context, machineID string, p PreflightPayload) (*Preflight, error)
 	RuleDownload(ctx context.Context, machineID string) ([]Rule, error)
-	UploadEvent(ctx context.Context, machineID string, body io.ReadCloser) error
+	UploadEvent(ctx context.Context, machineID string, body EventsList) error
 }
 
 type Datastore interface {


### PR DESCRIPTION
Reworks how event uploads are logged. Now you get 1 line of JSON per event, with the machine ID and a timestamp of when the server received the event tacked on.

The timestamp isn't super useful because events are sent in batches after the fact, but it should put some bound on when the event occurred in case the client's clock is extremely wrong.