### PR TITLE
Changed whitelist/blacklist to allowlist/blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ batch_size = 100
 
 [[rules]]
 rule_type = "BINARY"
-policy = "blocklist"
+policy = "BLOCKLIST"
 sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
 custom_msg = "blocklist firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "blocklist"
+policy = "BLOCKLIST"
 sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
 custom_msg = "blocklist dash app certificate"
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ BINARY | CERTIFICATE
 
 Values for `policy`:
 ```
-blocklist | allowlist
+BLOCKLIST | ALLOWLIST
 ```
 
 Use the `santactl` command to get the sha256 value: 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Moroz is a server for the [Santa](https://github.com/google/santa) project.
 
-> Santa is a binary whitelisting/blacklisting system for macOS. It consists of a kernel extension that monitors for executions, a userland daemon that makes execution decisions based on the contents of a SQLite database, a GUI agent that notifies the user in case of a block decision and a command-line utility for managing the system and synchronizing the database with a server.
+> Santa is a binary allowlisting/blocklisting system for macOS. It consists of a kernel extension that monitors for executions, a userland daemon that makes execution decisions based on the contents of a SQLite database, a GUI agent that notifies the user in case of a block decision and a command-line utility for managing the system and synchronizing the database with a server.
 >
 > Santa is a project of Google's Macintosh Operations Team.
 
@@ -21,21 +21,21 @@ Below is a sample configuration file:
 
 ```toml
 client_mode = "MONITOR"
-#blacklist_regex = "^(?:/Users)/.*"
-#whitelist_regex = "^(?:/Users)/.*"
+#blocklist_regex = "^(?:/Users)/.*"
+#allowlist_regex = "^(?:/Users)/.*"
 batch_size = 100
 
 [[rules]]
 rule_type = "BINARY"
-policy = "BLACKLIST"
+policy = "blocklist"
 sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
-custom_msg = "blacklist firefox"
+custom_msg = "blocklist firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "BLACKLIST"
+policy = "blocklist"
 sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-custom_msg = "blacklist dash app certificate"
+custom_msg = "blocklist dash app certificate"
 ```
 
 # Creating rules
@@ -52,7 +52,7 @@ BINARY | CERTIFICATE
 
 Values for `policy`:
 ```
-BLACKLIST | WHITELIST
+blocklist | allowlist
 ```
 
 Use the `santactl` command to get the sha256 value: 

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -37,6 +37,6 @@ custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "allowlist_COMPILER"
+policy = "ALLOWLIST_COMPILER"
 sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
 custom_msg = "allowlist go compiler component"

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -7,31 +7,31 @@ enabled_transitive_allowlisting = true
 
 [[rules]]
 rule_type = "BINARY"
-policy = "blocklist"
+policy = "BLOCKLIST"
 sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
 custom_msg = "blocklist firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "blocklist"
+policy = "BLOCKLIST"
 sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
 custom_msg = "blocklist dash app certificate"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "allowlist_COMPILER"
+policy = "ALLOWLIST_COMPILER"
 sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
 custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "allowlist_COMPILER"
+policy = "ALLOWLIST_COMPILER"
 sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
 custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "allowlist_COMPILER"
+policy = "ALLOWLIST_COMPILER"
 sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
 custom_msg = "allowlist go compiler component"
 

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -1,42 +1,42 @@
 client_mode = "MONITOR"
-# blacklist_regex = "^(?:/Users)/.*"
-# whitelist_regex = "^(?:/Users)/.*"
+# blocklist_regex = "^(?:/Users)/.*"
+# allowlist_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
-enabled_transitive_whitelisting = true
+enabled_transitive_allowlisting = true
 
 [[rules]]
 rule_type = "BINARY"
-policy = "BLACKLIST"
+policy = "blocklist"
 sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
-custom_msg = "blacklist firefox"
+custom_msg = "blocklist firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "BLACKLIST"
+policy = "blocklist"
 sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-custom_msg = "blacklist dash app certificate"
+custom_msg = "blocklist dash app certificate"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "allowlist_COMPILER"
 sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "allowlist_COMPILER"
 sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "allowlist_COMPILER"
 sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "allowlist_COMPILER"
 sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allowlist go compiler component"

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -27,11 +27,11 @@ type Rule struct {
 // Preflight representssync response sent to a Santa client by the sync server.
 type Preflight struct {
 	ClientMode                    ClientMode `json:"client_mode" toml:"client_mode"`
-	BlacklistRegex                string     `json:"blacklist_regex" toml:"blacklist_regex"`
-	WhitelistRegex                string     `json:"whitelist_regex" toml:"whitelist_regex"`
+	BlocklistRegex                string     `json:"blocklist_regex" toml:"blocklist_regex"`
+	AllowlistRegex                string     `json:"allowlist_regex" toml:"allowlist_regex"`
 	BatchSize                     int        `json:"batch_size" toml:"batch_size"`
 	EnableBundles                 bool       `json:"enable_bundles" toml:"enable_bundles"`
-	EnabledTransitiveWhitelisting bool       `json:"enabled_transitive_whitelisting" toml:"enabled_transitive_whitelisting"`
+	EnabledTransitiveallowlisting bool       `json:"enabled_transitive_allowlisting" toml:"enabled_transitive_allowlisting"`
 }
 
 // A PreflightPayload represents the request sent by a santa client to the sync server.
@@ -43,7 +43,7 @@ type PreflightPayload struct {
 	CertificateRuleCount int        `json:"certificate_rule_count"`
 	BinaryRuleCount      int        `json:"binary_rule_count"`
 	ClientMode           ClientMode `json:"client_mode"`
-	SerialNumber         string     `json:"serial_number"`
+	SerialNumber         string     `json:"serial_num"`
 	PrimaryUser          string     `json:"primary_user"`
 }
 
@@ -94,22 +94,22 @@ func (r RuleType) MarshalText() ([]byte, error) {
 type Policy int
 
 const (
-	Blacklist Policy = iota
-	Whitelist
+	Blocklist Policy = iota
+	allowlist
 
-	// WhitelistCompiler is a Transitive Whitelist policy which allows whitelisting binaries created by
-	// a specific compiler. EnabledTransitiveWhitelisting must be set to true in the Preflight first.
-	WhitelistCompiler
+	// allowlistCompiler is a Transitive allowlist policy which allows allowlisting binaries created by
+	// a specific compiler. EnabledTransitiveallowlisting must be set to true in the Preflight first.
+	allowlistCompiler
 )
 
 func (p *Policy) UnmarshalText(text []byte) error {
 	switch t := string(text); t {
-	case "BLACKLIST":
-		*p = Blacklist
-	case "WHITELIST":
-		*p = Whitelist
-	case "WHITELIST_COMPILER":
-		*p = WhitelistCompiler
+	case "BLOCKLIST":
+		*p = Blocklist
+	case "ALLOWLIST":
+		*p = allowlist
+	case "ALLOWLIST_COMPILER":
+		*p = allowlistCompiler
 	default:
 		return errors.Errorf("unknown policy value %q", t)
 	}
@@ -118,12 +118,12 @@ func (p *Policy) UnmarshalText(text []byte) error {
 
 func (p Policy) MarshalText() ([]byte, error) {
 	switch p {
-	case Blacklist:
-		return []byte("BLACKLIST"), nil
-	case Whitelist:
-		return []byte("WHITELIST"), nil
-	case WhitelistCompiler:
-		return []byte("WHITELIST_COMPILER"), nil
+	case Blocklist:
+		return []byte("BLOCKLIST"), nil
+	case allowlist:
+		return []byte("ALLOWLIST"), nil
+	case allowlistCompiler:
+		return []byte("ALLOWLIST_COMPILER"), nil
 	default:
 		return nil, errors.Errorf("unknown policy %d", p)
 	}

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -95,11 +95,11 @@ type Policy int
 
 const (
 	Blocklist Policy = iota
-	allowlist
+	Allowlist
 
-	// allowlistCompiler is a Transitive allowlist policy which allows allowlisting binaries created by
+	// AllowlistCompiler is a Transitive allowlist policy which allows allowlisting binaries created by
 	// a specific compiler. EnabledTransitiveallowlisting must be set to true in the Preflight first.
-	allowlistCompiler
+	AllowlistCompiler
 )
 
 func (p *Policy) UnmarshalText(text []byte) error {
@@ -107,9 +107,9 @@ func (p *Policy) UnmarshalText(text []byte) error {
 	case "BLOCKLIST":
 		*p = Blocklist
 	case "ALLOWLIST":
-		*p = allowlist
+		*p = Allowlist
 	case "ALLOWLIST_COMPILER":
-		*p = allowlistCompiler
+		*p = AllowlistCompiler
 	default:
 		return errors.Errorf("unknown policy value %q", t)
 	}
@@ -120,9 +120,9 @@ func (p Policy) MarshalText() ([]byte, error) {
 	switch p {
 	case Blocklist:
 		return []byte("BLOCKLIST"), nil
-	case allowlist:
+	case Allowlist:
 		return []byte("ALLOWLIST"), nil
-	case allowlistCompiler:
+	case AllowlistCompiler:
 		return []byte("ALLOWLIST_COMPILER"), nil
 	default:
 		return nil, errors.Errorf("unknown policy %d", p)

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -31,7 +31,7 @@ type Preflight struct {
 	AllowlistRegex                string     `json:"allowlist_regex" toml:"allowlist_regex"`
 	BatchSize                     int        `json:"batch_size" toml:"batch_size"`
 	EnableBundles                 bool       `json:"enable_bundles" toml:"enable_bundles"`
-	EnabledTransitiveallowlisting bool       `json:"enabled_transitive_allowlisting" toml:"enabled_transitive_allowlisting"`
+	EnabledTransitiveAllowlisting bool       `json:"enabled_transitive_allowlisting" toml:"enabled_transitive_allowlisting"`
 }
 
 // A PreflightPayload represents the request sent by a santa client to the sync server.
@@ -98,7 +98,7 @@ const (
 	Allowlist
 
 	// AllowlistCompiler is a Transitive allowlist policy which allows allowlisting binaries created by
-	// a specific compiler. EnabledTransitiveallowlisting must be set to true in the Preflight first.
+	// a specific compiler. EnabledTransitiveAllowlisting must be set to true in the Preflight first.
 	AllowlistCompiler
 )
 

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -24,15 +24,15 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have rule_type %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[0].Policy, Blacklist; have != want {
+	if have, want := conf.Rules[0].Policy, Blocklist; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[1].Policy, Whitelist; have != want {
+	if have, want := conf.Rules[1].Policy, allowlist; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[2].Policy, WhitelistCompiler; have != want {
+	if have, want := conf.Rules[2].Policy, allowlistCompiler; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -28,11 +28,11 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[1].Policy, allowlist; have != want {
+	if have, want := conf.Rules[1].Policy, Allowlist; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[2].Policy, allowlistCompiler; have != want {
+	if have, want := conf.Rules[2].Policy, AllowlistCompiler; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -1,42 +1,42 @@
 client_mode = "LOCKDOWN"
-blacklist_regex = "^(?:/Users)/.*"
-whitelist_regex = "^(?:/Users)/.*"
+blocklist_regex = "^(?:/Users)/.*"
+allowlist_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
-enabled_transitive_whitelisting = true
+enabled_transitive_allowlisting = true
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "BLACKLIST"
+  policy = "BLOCKLIST"
   sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
-  custom_msg = "blacklist firefox"
+  custom_msg = "blocklist firefox"
 
 [[rules]]
   rule_type = "CERTIFICATE"
-  policy = "WHITELIST"
+  policy = "ALLOWLIST"
   sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-  custom_msg = "blacklist dash app certificate"
+  custom_msg = "blocklist dash app certificate"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWLIST_COMPILER"
   sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allowlist go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWLIST_COMPILER"
   sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allowlist go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWLIST_COMPILER"
   sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allowlist go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWLIST_COMPILER"
   sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allowlist go compiler component"


### PR DESCRIPTION
As part of documenting the Santa sync protocol over at https://github.com/google/santa/pull/860. 

We'd like to clean up implementations that are using the old identifiers.