### PR TITLE
Update to Latest Santa Config and Inclusive Naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Moroz is a server for the [Santa](https://github.com/google/santa) project.
 
-> Santa is a binary whitelisting/blacklisting system for macOS. It consists of a kernel extension that monitors for executions, a userland daemon that makes execution decisions based on the contents of a SQLite database, a GUI agent that notifies the user in case of a block decision and a command-line utility for managing the system and synchronizing the database with a server.
+> Santa is a binary allow/block system for macOS. It consists of a kernel extension that monitors for executions, a userland daemon that makes execution decisions based on the contents of a SQLite database, a GUI agent that notifies the user in case of a block decision and a command-line utility for managing the system and synchronizing the database with a server.
 >
 > Santa is a project of Google's Macintosh Operations Team.
 
@@ -21,21 +21,27 @@ Below is a sample configuration file:
 
 ```toml
 client_mode = "MONITOR"
-#blacklist_regex = "^(?:/Users)/.*"
-#whitelist_regex = "^(?:/Users)/.*"
+#blocked_path_regex = "^(?:/Users)/.*"
+#allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 
 [[rules]]
 rule_type = "BINARY"
-policy = "BLACKLIST"
+policy = "BLOCK"
 sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
-custom_msg = "blacklist firefox"
+custom_msg = "block firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "BLACKLIST"
+policy = "ALLOW"
 sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-custom_msg = "blacklist dash app certificate"
+custom_msg = "allow dash app certificate"
+
+[[rules]]
+rule_type = "TEAMID"
+policy = "ALLOW"
+identifier = "59GAB85EFG"
+custom_msg = "allow Apple Team Id"
 ```
 
 # Creating rules
@@ -47,12 +53,12 @@ MONITOR | LOCKDOWN
 
 Values for `rule_type`:
 ```
-BINARY | CERTIFICATE
+BINARY | CERTIFICATE | TEAMID
 ```
 
 Values for `policy`:
 ```
-BLACKLIST | WHITELIST
+BLOCK | ALLOW
 ```
 
 Use the `santactl` command to get the sha256 value: 

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -19,25 +19,25 @@ custom_msg = "block dash app certificate"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOWED_COMPILER"
+policy = "ALLOW_COMPILER"
 sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOWED_COMPILER"
+policy = "ALLOW_COMPILER"
 sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOWED_COMPILER"
+policy = "ALLOW_COMPILER"
 sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOWED_COMPILER"
+policy = "ALLOW_COMPILER"
 sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
 custom_msg = "allow go compiler component"
 

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -7,42 +7,42 @@ enable_transitive_rules = true
 
 [[rules]]
 rule_type = "BINARY"
-policy = "BLOCK"
-sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
+policy = "BLOCKLIST"
+identifier = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
 custom_msg = "block firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "BLOCK"
-sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
+policy = "BLOCKLIST"
+identifier = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
 custom_msg = "block dash app certificate"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOW_COMPILER"
-sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
+policy = "ALLOWLIST_COMPILER"
+identifier = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOW_COMPILER"
-sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
+policy = "ALLOWLIST_COMPILER"
+identifier = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOW_COMPILER"
-sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
+policy = "ALLOWLIST_COMPILER"
+identifier = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "ALLOW_COMPILER"
-sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
+policy = "ALLOWLIST_COMPILER"
+identifier = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
 custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "TEAMID"
-policy = "ALLOW"
+policy = "ALLOWLIST"
 identifier = "59GAB85EFG"
 custom_msg = "allow Apple Team Id"

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -1,42 +1,48 @@
 client_mode = "MONITOR"
-# blacklist_regex = "^(?:/Users)/.*"
-# whitelist_regex = "^(?:/Users)/.*"
+# blocked_path_regex = "^(?:/Users)/.*"
+# allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
 enabled_transitive_whitelisting = true
 
 [[rules]]
 rule_type = "BINARY"
-policy = "BLACKLIST"
+policy = "BLOCK"
 sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
-custom_msg = "blacklist firefox"
+custom_msg = "block firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
-policy = "BLACKLIST"
+policy = "BLOCK"
 sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-custom_msg = "blacklist dash app certificate"
+custom_msg = "block dash app certificate"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "ALLOWED_COMPILER"
 sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "ALLOWED_COMPILER"
 sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "ALLOWED_COMPILER"
 sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allow go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
-policy = "WHITELIST_COMPILER"
+policy = "ALLOWED_COMPILER"
 sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
-custom_msg = "whitelist go compiler component"
+custom_msg = "allow go compiler component"
+
+[[rules]]
+rule_type = "TEAMID"
+policy = "ALLOW"
+identifier = "59GAB85EFG"
+custom_msg = "allow Apple Team Id"

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -3,7 +3,7 @@ client_mode = "MONITOR"
 # allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
-enabled_transitive_whitelisting = true
+enable_transitive_rules = true
 
 [[rules]]
 rule_type = "BINARY"

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -16,12 +16,11 @@ type Config struct {
 }
 
 // Rule is a Santa rule.
-// Full documentation: https://github.com/google/santa/blob/01df4623c7c534568ca3d310129455ff71cc3eef/Docs/details/rules.md
+// Full documentation: https://github.com/google/santa/blob/main/docs/concepts/rules.md
 type Rule struct {
 	RuleType      RuleType `json:"rule_type" toml:"rule_type"`
 	Policy        Policy   `json:"policy" toml:"policy"`
-	SHA256        string   `json:"sha256" toml:"sha256"`
-	Identifier    string   `json:"identifier,omitempty" toml:"identifier,omitempty"`
+	Identifier    string   `json:"identifier" toml:"identifier"`
 	CustomMessage string   `json:"custom_msg,omitempty" toml:"custom_msg,omitempty"`
 }
 
@@ -103,22 +102,22 @@ func (r RuleType) MarshalText() ([]byte, error) {
 type Policy int
 
 const (
-	Block Policy = iota
-	Allow
+	BlockList Policy = iota
+	AllowList
 
-	// AllowCompiler is a Transitive Allow policy which allows adding binaries created by
-	// a specific compiler to an Allow List. EnableTransitiveRules must be set to true in the Preflight first.
-	AllowCompiler
+	// AllowListCompiler is a Transitive AllowList policy which allows adding binaries created by
+	// a specific compiler to an AllowList. EnableTransitiveRules must be set to true in the Preflight first.
+	AllowListCompiler
 )
 
 func (p *Policy) UnmarshalText(text []byte) error {
 	switch t := string(text); t {
-	case "BLOCK":
-		*p = Block
-	case "ALLOW":
-		*p = Allow
-	case "ALLOW_COMPILER":
-		*p = AllowCompiler
+	case "BLOCKLIST":
+		*p = BlockList
+	case "ALLOWLIST":
+		*p = AllowList
+	case "ALLOWLIST_COMPILER":
+		*p = AllowListCompiler
 	default:
 		return errors.Errorf("unknown policy value %q", t)
 	}
@@ -127,12 +126,12 @@ func (p *Policy) UnmarshalText(text []byte) error {
 
 func (p Policy) MarshalText() ([]byte, error) {
 	switch p {
-	case Block:
-		return []byte("BLOCK"), nil
-	case Allow:
-		return []byte("ALLOW"), nil
-	case AllowCompiler:
-		return []byte("ALLOW_COMPILER"), nil
+	case BlockList:
+		return []byte("BLOCKLIST"), nil
+	case AllowList:
+		return []byte("ALLOWLIST"), nil
+	case AllowListCompiler:
+		return []byte("ALLOWLIST_COMPILER"), nil
 	default:
 		return nil, errors.Errorf("unknown policy %d", p)
 	}

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -27,12 +27,12 @@ type Rule struct {
 
 // Preflight representssync response sent to a Santa client by the sync server.
 type Preflight struct {
-	ClientMode             ClientMode `json:"client_mode" toml:"client_mode"`
-	BlockedPathRegex       string     `json:"blocked_path_regex" toml:"blocked_path_regex"`
-	AllowedPathRegex       string     `json:"allowed_path_regex" toml:"allowed_path_regex"`
-	BatchSize              int        `json:"batch_size" toml:"batch_size"`
-	EnableBundles          bool       `json:"enable_bundles" toml:"enable_bundles"`
-	EnabledTransitiveRules bool       `json:"enable_transitive_rules" toml:"enable_transitive_rules"`
+	ClientMode            ClientMode `json:"client_mode" toml:"client_mode"`
+	BlockedPathRegex      string     `json:"blocked_path_regex" toml:"blocked_path_regex"`
+	AllowedPathRegex      string     `json:"allowed_path_regex" toml:"allowed_path_regex"`
+	BatchSize             int        `json:"batch_size" toml:"batch_size"`
+	EnableBundles         bool       `json:"enable_bundles" toml:"enable_bundles"`
+	EnableTransitiveRules bool       `json:"enable_transitive_rules" toml:"enable_transitive_rules"`
 }
 
 // A PreflightPayload represents the request sent by a santa client to the sync server.
@@ -107,7 +107,7 @@ const (
 	Allow
 
 	// AllowCompiler is a Transitive Allow policy which allows adding binaries created by
-	// a specific compiler to an Allow List. EnabledTransitiveRules must be set to true in the Preflight first.
+	// a specific compiler to an Allow List. EnableTransitiveRules must be set to true in the Preflight first.
 	AllowCompiler
 )
 

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -28,15 +28,15 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have rule_type %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[0].Policy, Block; have != want {
+	if have, want := conf.Rules[0].Policy, BlockList; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[1].Policy, Allow; have != want {
+	if have, want := conf.Rules[1].Policy, AllowList; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[2].Policy, AllowCompiler; have != want {
+	if have, want := conf.Rules[2].Policy, AllowListCompiler; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -24,15 +24,15 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have rule_type %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[0].Policy, Blacklist; have != want {
+	if have, want := conf.Rules[0].Policy, Block; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[1].Policy, Whitelist; have != want {
+	if have, want := conf.Rules[1].Policy, Allow; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[2].Policy, WhitelistCompiler; have != want {
+	if have, want := conf.Rules[2].Policy, AllowCompiler; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -24,6 +24,10 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have rule_type %d, want %d\n", have, want)
 	}
 
+	if have, want := conf.Rules[6].RuleType, TeamId; have != want {
+		t.Errorf("have rule_type %d, want %d\n", have, want)
+	}
+
 	if have, want := conf.Rules[0].Policy, Block; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -7,43 +7,42 @@ enable_transitive_rules = true
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "BLOCK"
-  sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
+  policy = "BLOCKLIST"
+  identifier = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
   custom_msg = "block firefox"
 
 [[rules]]
   rule_type = "CERTIFICATE"
-  policy = "ALLOW"
-  sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
+  policy = "ALLOWLIST"
+  identifier = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
   custom_msg = "allow dash app certificate"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOW_COMPILER"
-  sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
+  policy = "ALLOWLIST_COMPILER"
+  identifier = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOW_COMPILER"
-  sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
+  policy = "ALLOWLIST_COMPILER"
+  identifier = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOW_COMPILER"
-  sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
+  policy = "ALLOWLIST_COMPILER"
+  identifier = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOW_COMPILER"
-  sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
+  policy = "ALLOWLIST_COMPILER"
+  identifier = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "TEAMID"
-  policy = "ALLOW"
-  sha256 = ""
+  policy = "ALLOWLIST"
   identifier = "59GAB85EFG"
   custom_msg = "allow Apple Team Id"

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -19,24 +19,24 @@ enabled_transitive_whitelisting = true
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOWED_COMPILER"
+  policy = "ALLOW_COMPILER"
   sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOWED_COMPILER"
+  policy = "ALLOW_COMPILER"
   sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOWED_COMPILER"
+  policy = "ALLOW_COMPILER"
   sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
   custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "ALLOWED_COMPILER"
+  policy = "ALLOW_COMPILER"
   sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
   custom_msg = "allow go compiler component"

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -1,42 +1,42 @@
 client_mode = "LOCKDOWN"
-blacklist_regex = "^(?:/Users)/.*"
-whitelist_regex = "^(?:/Users)/.*"
+allowed_path_regex = "^(?:/Users)/.*"
+blocked_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
 enabled_transitive_whitelisting = true
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "BLACKLIST"
+  policy = "BLOCK"
   sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
-  custom_msg = "blacklist firefox"
+  custom_msg = "block firefox"
 
 [[rules]]
   rule_type = "CERTIFICATE"
-  policy = "WHITELIST"
+  policy = "ALLOW"
   sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-  custom_msg = "blacklist dash app certificate"
+  custom_msg = "allow dash app certificate"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWED_COMPILER"
   sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWED_COMPILER"
   sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWED_COMPILER"
   sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allow go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
-  policy = "WHITELIST_COMPILER"
+  policy = "ALLOWED_COMPILER"
   sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
-  custom_msg = "whitelist go compiler component"
+  custom_msg = "allow go compiler component"

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -1,9 +1,9 @@
 client_mode = "LOCKDOWN"
-allowed_path_regex = "^(?:/Users)/.*"
 blocked_path_regex = "^(?:/Users)/.*"
+allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
-enabled_transitive_whitelisting = true
+enable_transitive_rules = true
 
 [[rules]]
   rule_type = "BINARY"
@@ -40,3 +40,10 @@ enabled_transitive_whitelisting = true
   policy = "ALLOW_COMPILER"
   sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
   custom_msg = "allow go compiler component"
+
+[[rules]]
+  rule_type = "TEAMID"
+  policy = "ALLOW"
+  sha256 = ""
+  identifier = "59GAB85EFG"
+  custom_msg = "allow Apple Team Id"


### PR DESCRIPTION
This PR seeks to bring the Moroz code up to date with the latest Santa. It does the following things:

- Make the library more inclusive by changing rule type `Whitelist` to `Allow` (Allowed) and `Blacklist` to `Block` (Blocked) in line with Santa
- Update the `json` and `toml` marshaling tags for whitelist_regex and blacklist_regex in line with Santa's expected `allowed_file_regex` and `blocked_file_regex` respectively.
- Add `TeamId` to the list of policies that can be allowed or blocked in addition to the existing `Binary` and `Certificate`. This is an even more powerful rule with broader reach than individual certificate rules