### PR TITLE
Update moroz based on latest santa client

### DIFF
--- a/cmd/moroz/main.go
+++ b/cmd/moroz/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	if _, err := os.Stat(*flTLSCert); *flUseTLS && os.IsNotExist(err) {
-		fmt.Println(openSSLBash)
+		fmt.Printf(openSSLBash)
 		os.Exit(2)
 	}
 

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -1,42 +1,56 @@
 client_mode = "MONITOR"
-# blocklist_regex = "^(?:/Users)/.*"
-# allowlist_regex = "^(?:/Users)/.*"
+# blocked_path_regex = "^(?:/Users)/.*"
+# allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
-enabled_transitive_allowlisting = true
+enable_transitive_rules = true
+clean_sync = true
+full_sync_interval = 600
 
 [[rules]]
 rule_type = "BINARY"
 policy = "BLOCKLIST"
-sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
+identifier = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
 custom_msg = "blocklist firefox"
 
 [[rules]]
-rule_type = "CERTIFICATE"
+rule_type = "TEAMID"
+policy = "ALLOWLIST"
+identifier = "EQHXZ8M8AV"
+custom_msg = "allow google team id"
+
+[[rules]]
+rule_type = "SIGNINGID"
+policy = "ALLOWLIST"
+identifier = "EQHXZ8M8AV:com.google.Chrome"
+custom_msg = "allow google chrome signing id"
+
+[[rules]]
+rule_type = "SIGNINGID"
 policy = "BLOCKLIST"
-sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-custom_msg = "blocklist dash app certificate"
+identifier = "platform:com.apple.BluetoothFileExchange"
+custom_msg = "block bluetooth file exchange.app"
 
 [[rules]]
 rule_type = "BINARY"
 policy = "ALLOWLIST_COMPILER"
-sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
+identifier = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
 custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
 policy = "ALLOWLIST_COMPILER"
-sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
+identifier = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
 custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
 policy = "ALLOWLIST_COMPILER"
-sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
+identifier = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
 custom_msg = "allowlist go compiler component"
 
 [[rules]]
 rule_type = "BINARY"
 policy = "ALLOWLIST_COMPILER"
-sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
+identifier = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
 custom_msg = "allowlist go compiler component"

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -16,11 +16,31 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have client_mode %d, want %d\n", have, want)
 	}
 
+	if have, want := conf.CleanSync, true; have != want {
+		t.Errorf("have clean_sync %t, want %t\n", have, want)
+	}
+
+	if have, want := conf.FullSyncInterval, 600; have != want {
+		t.Errorf("have full_sync_interval %d, want %d\n", have, want)
+	}
+
+	if have, want := conf.Rules[0].Identifier, "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"; have != want {
+		t.Errorf("have identifier %s, want %s\n", have, want)
+	}
+
 	if have, want := conf.Rules[0].RuleType, Binary; have != want {
 		t.Errorf("have rule_type %d, want %d\n", have, want)
 	}
 
 	if have, want := conf.Rules[1].RuleType, Certificate; have != want {
+		t.Errorf("have rule_type %d, want %d\n", have, want)
+	}
+
+	if have, want := conf.Rules[2].RuleType, TeamID; have != want {
+		t.Errorf("have rule_tpe %d, want %d\n", have, want)
+	}
+
+	if have, want := conf.Rules[3].RuleType, SigningID; have != want {
 		t.Errorf("have rule_type %d, want %d\n", have, want)
 	}
 
@@ -32,10 +52,13 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
-	if have, want := conf.Rules[2].Policy, AllowlistCompiler; have != want {
+	if have, want := conf.Rules[4].Policy, AllowlistCompiler; have != want {
 		t.Errorf("have policy %d, want %d\n", have, want)
 	}
 
+	if have, want := conf.Rules[5].Policy, Remove; have != want {
+		t.Errorf("have policy %d, want %d\n", have, want)
+	}
 }
 
 func testConfig(t *testing.T, path string, replace bool) Config {

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -1,42 +1,62 @@
 client_mode = "LOCKDOWN"
-blocklist_regex = "^(?:/Users)/.*"
-allowlist_regex = "^(?:/Users)/.*"
+blocked_path_regex = "^(?:/Users)/.*"
+allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
 enable_bundles = false
-enabled_transitive_allowlisting = true
+enable_transitive_rules = true
+clean_sync = true
+full_sync_interval = 600
 
 [[rules]]
   rule_type = "BINARY"
   policy = "BLOCKLIST"
-  sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
+  identifier = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
   custom_msg = "blocklist firefox"
 
 [[rules]]
   rule_type = "CERTIFICATE"
   policy = "ALLOWLIST"
-  sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
-  custom_msg = "blocklist dash app certificate"
+  identifier = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
+  custom_msg = "allowlist dash app certificate"
+
+[[rules]]
+  rule_type = "TEAMID"
+  policy = "ALLOWLIST"
+  identifier = "EQHXZ8M8AV"
+  custom_msg = "allow google team id"
+
+[[rules]]
+  rule_type = "SIGNINGID"
+  policy = "ALLOWLIST"
+  identifier = "EQHXZ8M8AV:com.google.Chrome"
+  custom_msg = "allow google chrome signing id"
 
 [[rules]]
   rule_type = "BINARY"
   policy = "ALLOWLIST_COMPILER"
-  sha256 = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
+  identifier = "60d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
+  custom_msg = "allowlist go compiler component"
+
+[[rules]]
+  rule_type = "BINARY"
+  policy = "REMOVE"
+  identifier = "50d79d1763fefb56716e4a36284300523eb4335c3726fb9070fa83074b02279e"
+  custom_msg = "remove allowlist of the go compiler component"
+
+[[rules]]
+  rule_type = "BINARY"
+  policy = "ALLOWLIST_COMPILER"
+  identifier = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
   custom_msg = "allowlist go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
   policy = "ALLOWLIST_COMPILER"
-  sha256 = "8e78770685d51324b78588fddc6afc2f8b6cef5231c27eeb97363cc437fec18a"
+  identifier = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
   custom_msg = "allowlist go compiler component"
 
 [[rules]]
   rule_type = "BINARY"
   policy = "ALLOWLIST_COMPILER"
-  sha256 = "e88617cfd62809fb10e213c459a52f48e028fae4321e41134c4797465af886b6"
-  custom_msg = "allowlist go compiler component"
-
-[[rules]]
-  rule_type = "BINARY"
-  policy = "ALLOWLIST_COMPILER"
-  sha256 = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
+  identifier = "d867fca68bbd7db18e9ced231800e7535bc067852b1e530987bb7f57b5e3a02c"
   custom_msg = "allowlist go compiler component"


### PR DESCRIPTION
Bringing in the latest changes based on https://santa.dev/development/sync-protocol.html

Removals on Rule type:
- removes `sha256` field, seems to be deprecated? Going forward, all rules will use the `identifier` field for the sha256, team id, or signing id value.

Additions to Rule type:
- adds team id rule type
- adds signing id rule type

Additions to Preflight response:
- adds `full_sync_interval`. This is a required in the response from the server

Additions to Policy type:
- adds `REMOVE` policy for instances that an admin wants the santa client to remove a rule

Updates all tests.

Local test (client):
```
❯ sudo santactl sync --debug
SyncBaseURL is not over HTTPS!
Preflight starting
Performing request, attempt 1
Clean sync requested by server
Preflight complete
Event upload starting
Event upload complete
Rule download starting
Performing request, attempt 1
Received 8 rules
Processed 8 rules
Rule download complete
Postflight starting
Performing request, attempt 1
Postflight complete
Sync completed successfully
❯ santactl status
>>> Daemon Info
  Mode                      | Monitor
  Log Type                  | syslog
  File Logging              | Yes
  USB Blocking              | No
  Watchdog CPU Events       | 0  (Peak: 11.77%)
  Watchdog RAM Events       | 0  (Peak: 233.80MB)
>>> Cache Info
  Root cache count          | 146
  Non-root cache count      | 0
>>> Database Info
  Binary Rules              | 5
  Certificate Rules         | 0
  TeamID Rules              | 1
  SigningID Rules           | 2
  Compiler Rules            | 4
  Transitive Rules          | 0
  Events Pending Upload     | 42
>>> Watch Items
  Enabled                   | No
>>> Sync Info
  Sync Server               | http://santa/v1/santa/
  Clean Sync Required       | No
  Last Successful Full Sync | 2023/06/07 13:03:21 -0500
  Last Successful Rule Sync | 2023/06/07 13:03:21 -0500
  Push Notifications        | Disconnected
  Bundle Scanning           | No
  Transitive Rules          | Yes
```

Server side logs:
```
❯ ./build/darwin/moroz -configs ./configs/global.toml -http-addr=:80 -tls-cert ./server.crt -tls-key ./server.key -use-tls=false -debug
{"addr":":80","caller":"main.go:109","msg":"serve http","severity":"debug","tls":false,"ts":"2023-06-07T18:02:56.845724Z"}
{"caller":"svc_preflight.go:75","err":null,"machine_id":"eng","method":"Preflight","severity":"info","took":"297.75µs","ts":"2023-06-07T18:02:59.787469Z"}
{"caller":"svc_rule_download.go:69","err":null,"machine_id":"eng","method":"RuleDownload","severity":"info","took":"235.208µs","ts":"2023-06-07T18:02:59.791313Z"}
{"caller":"svc_preflight.go:75","err":null,"machine_id":"eng","method":"Preflight","severity":"info","took":"509.875µs","ts":"2023-06-07T18:03:21.625395Z"}
{"caller":"svc_rule_download.go:69","err":null,"machine_id":"eng","method":"RuleDownload","severity":"info","took":"336.667µs","ts":"2023-06-07T18:03:21.632821Z"}
```

Local test log:
```
go test -cover -race -v github.com/groob/moroz/cmd/moroz github.com/groob/moroz/moroz github.com/groob/moroz/santa github.com/groob/moroz/santaconfig
?   	github.com/groob/moroz/cmd/moroz	[no test files]
?   	github.com/groob/moroz/moroz	[no test files]
=== RUN   TestConfigMarshalUnmarshal
--- PASS: TestConfigMarshalUnmarshal (0.00s)
PASS
coverage: 77.1% of statements
ok  	github.com/groob/moroz/santa	(cached)	coverage: 77.1% of statements
?   	github.com/groob/moroz/santaconfig	[no test files]
```