### PR TITLE
Change localhost to moroz.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The latest version of Santa is available on the GitHub repo page: https://github
 ## Configure Santa:
 You will need to provide the `SyncBaseURL` settings. See the [Santa repo](https://github.com/google/santa/blob/01df4623c7c534568ca3d310129455ff71cc3eef/Docs/deployment/configuration.md#important) for a complete guide on all the client configuration options.
 
-A likely value for local testing as in the Quickstart will be: `https://moroz.local:8934/v1/santa/`
+A likely value for local testing as in the Quickstart will be: `https://moroz.local:8080/v1/santa/`
 
 ## Start moroz:
 Assumes you have the `./server.crt` and `./server.key` files.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Generate a self-signed certificate which will be used by Santa clients and the s
 Add the Santa CN to your hosts file.
 
 ```
-sudo echo "127.0.0.1 santa" >> /etc/hosts
+sudo echo "127.0.0.1 moroz.local" >> /etc/hosts
 ```
 
 Add the self-signed cert to your system roots. 
@@ -130,6 +130,8 @@ The latest version of Santa is available on the GitHub repo page: https://github
 
 ## Configure Santa:
 You will need to provide the `SyncBaseURL` settings. See the [Santa repo](https://github.com/google/santa/blob/01df4623c7c534568ca3d310129455ff71cc3eef/Docs/deployment/configuration.md#important) for a complete guide on all the client configuration options.
+
+A likely value for local testing as in the Quickstart will be: `https://moroz.local:8934/v1/santa/`
 
 ## Start moroz:
 Assumes you have the `./server.crt` and `./server.key` files.

--- a/tools/dev/certificate/create
+++ b/tools/dev/certificate/create
@@ -2,6 +2,8 @@
 
 openssl genrsa -out server.key 2048
 openssl rsa -in server.key -out server.key
-openssl req -sha256 -new -key server.key -out server.csr -subj "/CN=santa"
-openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
+openssl req -sha256 -new -key server.key -out server.csr \
+    -subj "/CN=moroz.local" \
+    -addext "subjectAltName = DNS:moroz.local" 
+openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt -copy_extensions=copyall
 rm -f server.csr


### PR DESCRIPTION
I ran into issues with Santa not accepting the cert based on CN alone, and instead needing DN.

I also feel like the FQDN should reflect that the entity being contacted is `moroz` and not `santa`.

This required a change to the OpenSSL script to rely on a somewhat new feature for including extensions such as SANs. There is a negative here that the script now won't work with old OpenSSL versions.