### PR TITLE
Add upload event struct and log execution events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  build-go1.11:
+  build-go1.20:
     docker:
-        - image: golang:1.11
+        - image: golang:1.20
 
     working_directory: /go/src/github.com/groob/moroz
     steps:
@@ -15,5 +15,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-go1.11
+      - build-go1.20
 

--- a/configs/global.toml
+++ b/configs/global.toml
@@ -2,6 +2,7 @@ client_mode = "MONITOR"
 # blocked_path_regex = "^(?:/Users)/.*"
 # allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
+enable_all_event_upload = true
 enable_bundles = false
 enable_transitive_rules = true
 clean_sync = true

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,20 @@
 module github.com/groob/moroz
 
+go 1.20
+
 require (
 	github.com/BurntSushi/toml v0.2.0
 	github.com/go-kit/kit v0.4.0
+	github.com/gorilla/mux v1.6.1
+	github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0
+	github.com/oklog/run v1.0.0
+	github.com/pkg/errors v0.8.0
+)
+
+require (
 	github.com/go-logfmt/logfmt v0.3.0 // indirect
 	github.com/go-stack/stack v1.7.0 // indirect
 	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f // indirect
-	github.com/gorilla/mux v1.6.1
-	github.com/kolide/kit v0.0.0-20180912215818-0c28f72eb2b0
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
-	github.com/oklog/run v1.0.0
-	github.com/pkg/errors v0.8.0
 	golang.org/x/net v0.0.0-20180124060956-0ed95abb35c4 // indirect
 )

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -2,8 +2,6 @@
 package santa
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 )
 
@@ -24,12 +22,13 @@ type Rule struct {
 	CustomMessage string   `json:"custom_msg,omitempty" toml:"custom_msg,omitempty"`
 }
 
-// Preflight representssync response sent to a Santa client by the sync server.
+// Preflight represents sync response sent to a Santa client by the sync server.
 type Preflight struct {
 	ClientMode            ClientMode `json:"client_mode" toml:"client_mode"`
 	BlockedPathRegex      string     `json:"blocked_path_regex" toml:"blocked_path_regex"`
 	AllowedPathRegex      string     `json:"allowed_path_regex" toml:"allowed_path_regex"`
 	BatchSize             int        `json:"batch_size" toml:"batch_size"`
+	EnableAllEventUpload  bool       `json:"enable_all_event_upload" toml:"enable_all_event_upload"`
 	EnableBundles         bool       `json:"enable_bundles" toml:"enable_bundles"`
 	EnableTransitiveRules bool       `json:"enable_transitive_rules" toml:"enable_transitive_rules"`
 	CleanSync             bool       `json:"clean_sync" toml:"clean_sync"`
@@ -51,9 +50,55 @@ type PreflightPayload struct {
 
 // EventPayload represents derived metadata for events uploaded with the UploadEvent endpoint.
 type EventPayload struct {
-	FileSHA  string          `json:"file_sha256"`
-	UnixTime float64         `json:"execution_time"`
-	Content  json.RawMessage `json:"-"`
+	FileSHA   string  `json:"file_sha256"`
+	UnixTime  float64 `json:"execution_time"`
+	EventInfo EventUploadEvent
+}
+
+// EventUploadRequest encapsulation of an /eventupload POST body sent by a Santa client
+type EventUploadRequest struct {
+	Events []EventUploadEvent `json:"events"`
+}
+
+// EventUploadEvent is a single event entry
+type EventUploadEvent struct {
+	CurrentSessions              []string       `json:"current_sessions"`
+	Decision                     string         `json:"decision"`
+	ExecutingUser                string         `json:"executing_user"`
+	ExecutionTime                float64        `json:"execution_time"`
+	FileBundleBinaryCount        int64          `json:"file_bundle_binary_count"`
+	FileBundleExecutableRelPath  string         `json:"file_bundle_executable_rel_path"`
+	FileBundleHash               string         `json:"file_bundle_hash"`
+	FileBundleHashMilliseconds   float64        `json:"file_bundle_hash_millis"`
+	FileBundleID                 string         `json:"file_bundle_id"`
+	FileBundleName               string         `json:"file_bundle_name"`
+	FileBundlePath               string         `json:"file_bundle_path"`
+	FileBundleShortVersionString string         `json:"file_bundle_version_string"`
+	FileBundleVersion            string         `json:"file_bundle_version"`
+	FileName                     string         `json:"file_name"`
+	FilePath                     string         `json:"file_path"`
+	FileSHA256                   string         `json:"file_sha256"`
+	LoggedInUsers                []string       `json:"logged_in_users"`
+	ParentName                   string         `json:"parent_name"`
+	ParentProcessID              int            `json:"ppid"`
+	ProcessID                    int            `json:"pid"`
+	QuarantineAgentBundleID      string         `json:"quarantine_agent_bundle_id"`
+	QuarantineDataUrl            string         `json:"quarantine_data_url"`
+	QuarantineRefererUrl         string         `json:"quarantine_referer_url"`
+	QuarantineTimestamp          float64        `json:"quarantine_timestamp"`
+	SigningChain                 []SigningEntry `json:"signing_chain"`
+	SigningID                    string         `json:"signing_id"`
+	TeamID                       string         `json:"team_id"`
+}
+
+// SigningEntry is optionally present when an event includes a binary that is signed
+type SigningEntry struct {
+	CertificateName    string `json:"cn"`
+	Organization       string `json:"org"`
+	OrganizationalUnit string `json:"ou"`
+	SHA256             string `json:"sha256"`
+	ValidFrom          int    `json:"valid_from"`
+	ValidUntil         int    `json:"valid_until"`
 }
 
 // RuleType represents a Santa rule type.

--- a/santa/santa_test.go
+++ b/santa/santa_test.go
@@ -2,7 +2,6 @@ package santa
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -64,7 +63,7 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 func testConfig(t *testing.T, path string, replace bool) Config {
 	t.Helper()
 
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("loading config from path %q, err = %q\n", path, err)
 	}
@@ -80,7 +79,7 @@ func testConfig(t *testing.T, path string, replace bool) Config {
 	}
 
 	if replace {
-		if err := ioutil.WriteFile(path, buf.Bytes(), os.ModePerm); err != nil {
+		if err := os.WriteFile(path, buf.Bytes(), os.ModePerm); err != nil {
 			t.Fatalf("replace config at path %q, err = %q\n", path, err)
 		}
 		return testConfig(t, path, false)

--- a/santa/testdata/config_a_toml.golden
+++ b/santa/testdata/config_a_toml.golden
@@ -2,6 +2,7 @@ client_mode = "LOCKDOWN"
 blocked_path_regex = "^(?:/Users)/.*"
 allowed_path_regex = "^(?:/Users)/.*"
 batch_size = 100
+enable_all_event_upload = true
 enable_bundles = false
 enable_transitive_rules = true
 clean_sync = true

--- a/santaconfig/config.go
+++ b/santaconfig/config.go
@@ -2,7 +2,6 @@ package santaconfig
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +71,7 @@ func loadConfigs(path string) ([]santa.Config, error) {
 		if filepath.Ext(info.Name()) != ".toml" {
 			return nil
 		}
-		file, err := ioutil.ReadFile(path)
+		file, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Summary

Adds new types:
- `EventUploadRequest` - encapsulation of an /eventupload POST body sent by a Santa client. It's an array of santa events (see next type)
- `EventUploadEvent` - a single event entry. This contains all the data the santa client collected around the block event.

Updates:
- Bumps go version to 1.20
- Changes the `EventPayload.Content` field to `EventPayload.EventInfo`. The former was a raw json type, it's replaced with a more specific type
- Changes logging to show the execution events out in the log so the admin can see what was blocked. This is nice, because any logging backend can parse out the structured event fields easily.
- Prior to this, Moroz was only logging the count of events and then writing them as a json file to `/tmp/santa_events`. That's nice and all, but it is not helpful in environments that use ephemeral containers.

For more info on the santa client upload fields, see https://santa.dev/development/sync-protocol.html#eventupload


### Test plan

Ensure `enable_all_event_upload = true` is present in my toml config

Started server locally and tried to run a blocked application on my machine. The events are immediately sent to moroz from my santa client:

```
❯ ./build/darwin/moroz -configs ./configs/global.toml -http-addr=:3000 -use-tls=false -debug

{"addr":":3000","caller":"main.go:109","msg":"serve http","severity":"debug","tls":false,"ts":"2023-12-20T17:14:50.999877Z"}

{"caller":"svc_preflight.go:75","err":null,"machine_id":"brandonfriess","method":"Preflight","severity":"info","took":"443.792µs","ts":"2023-12-20T17:15:05.55886Z"}

{"caller":"svc_upload_event.go:106","err":null,"event":{"current_sessions":["brandonfriess@console","brandonfriess@ttys001","brandonfriess@ttys000","brandonfriess@ttys002","brandonfriess@ttys003","brandonfriess@ttys004","brandonfriess@ttys005"],"decision":"ALLOW_CERTIFICATE","executing_user":"root","execution_time":1703092487.530034,"file_bundle_binary_count":0,"file_bundle_executable_rel_path":"","file_bundle_hash":"","file_bundle_hash_millis":0,"file_bundle_id":"","file_bundle_name":"","file_bundle_path":"","file_bundle_version_string":"","file_bundle_version":"","file_name":"arch","file_path":"/usr/bin","file_sha256":"7cdb2cad3686c0d659d3ef39fefa567964437f3dfd5f134fb399e031b92294c1","logged_in_users":["brandonfriess"],"parent_name":"Python","ppid":31416,"pid":31422,"quarantine_agent_bundle_id":"","quarantine_data_url":"","quarantine_referer_url":"","quarantine_timestamp":0,"signing_chain":[{"cn":"Software Signing","org":"Apple Inc.","ou":"Apple Software","sha256":"d84db96af8c2e60ac4c851a21ec460f6f84e0235beb17d24a78712b9b021ed57","valid_from":1603996358,"valid_until":1792863581},{"cn":"Apple Code Signing Certification Authority","org":"Apple Inc.","ou":"Apple Certification Authority","sha256":"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77de2b95e051e2562","valid_from":1319477981,"valid_until":1792863581},{"cn":"Apple Root CA","org":"Apple Inc.","ou":"Apple Certification Authority","sha256":"b0b1730ecbc7ff4505142c49f1295e6eda6bcaed7e2c68c5be91b5a11001f024","valid_from":1146001236,"valid_until":2054670036}],"signing_id":"platform:com.apple.arch","team_id":""},"machine_id":"brandonfriess","method":"UploadEvent","severity":"info","took":"18.417375ms","ts":"2023-12-20T17:15:05.63825Z"}

{"caller":"svc_upload_event.go:106","err":null,"event":{"current_sessions":["brandonfriess@console","brandonfriess@ttys001","brandonfriess@ttys000","brandonfriess@ttys002","brandonfriess@ttys003","brandonfriess@ttys004","brandonfriess@ttys005"],"decision":"ALLOW_SCOPE","executing_user":"brandonfriess","execution_time":1703092414.421201,"file_bundle_binary_count":0,"file_bundle_executable_rel_path":"","file_bundle_hash":"","file_bundle_hash_millis":0,"file_bundle_id":"","file_bundle_name":"","file_bundle_path":"","file_bundle_version_string":"","file_bundle_version":"","file_name":"asm","file_path":"/opt/homebrew/Cellar/go/1.20.7/libexec/pkg/tool/darwin_arm64","file_sha256":"98cfa707deb8c0fcd785b3dde7292d6a9ba8eb7651b5e48d15a61cb959d1859c","logged_in_users":["brandonfriess"],"parent_name":"go","ppid":30143,"pid":30155,"quarantine_agent_bundle_id":"","quarantine_data_url":"","quarantine_referer_url":"","quarantine_timestamp":0,"signing_chain":[],"signing_id":"","team_id":""},"machine_id":"brandonfriess","method":"UploadEvent","severity":"info","took":"18.527542ms","ts":"2023-12-20T17:15:05.638347Z"}
```

Json file still exist on disk as well:
```
❯ bat /tmp/santa_events/01d2871fe74f82a3a436d0eb4952f5a31e73de1d5aebcca520c728085d03fddd/brandonfriess/1703092298.278724.json
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /tmp/santa_events/01d2871fe74f82a3a436d0eb4952f5a31e73de1d5aebcca520c728085d03fddd/brandonfriess/1703092298.278724.json
       │ Size: 1.5 KB
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ {"current_sessions":["brandonfriess@console","brandonfriess@ttys001","brandonfriess@ttys000","brandonfriess@ttys002","brandonfriess@ttys003","brandonfriess@ttys004","brandon
       │ friess@ttys005"],"decision":"ALLOW_CERTIFICATE","executing_user":"root","execution_time":1703092298.278724,"file_bundle_binary_count":0,"file_bundle_executable_rel_path":"",
       │ "file_bundle_hash":"","file_bundle_hash_millis":0,"file_bundle_id":"","file_bundle_name":"","file_bundle_path":"","file_bundle_version_string":"","file_bundle_version":"","f
       │ ile_name":"defaults","file_path":"/usr/bin","file_sha256":"01d2871fe74f82a3a436d0eb4952f5a31e73de1d5aebcca520c728085d03fddd","logged_in_users":["brandonfriess"],"parent_name
       │ ":"jamf","ppid":28173,"pid":28179,"quarantine_agent_bundle_id":"","quarantine_data_url":"","quarantine_referer_url":"","quarantine_timestamp":0,"signing_chain":[{"cn":"Softw
       │ are Signing","org":"Apple Inc.","ou":"Apple Software","sha256":"d84db96af8c2e60ac4c851a21ec460f6f84e0235beb17d24a78712b9b021ed57","valid_from":1603996358,"valid_until":17928
       │ 63581},{"cn":"Apple Code Signing Certification Authority","org":"Apple Inc.","ou":"Apple Certification Authority","sha256":"5bdab1288fc16892fef50c658db54f1e2e19cf8f71cc55f77
       │ de2b95e051e2562","valid_from":1319477981,"valid_until":1792863581},{"cn":"Apple Root CA","org":"Apple Inc.","ou":"Apple Certification Authority","sha256":"b0b1730ecbc7ff4505
       │ 142c49f1295e6eda6bcaed7e2c68c5be91b5a11001f024","valid_from":1146001236,"valid_until":2054670036}],"signing_id":"platform:com.apple.defaults","team_id":""}
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

