### PR TITLE
Append a newline to eventInfoJSON

### DIFF
--- a/moroz/svc_upload_event.go
+++ b/moroz/svc_upload_event.go
@@ -30,6 +30,8 @@ func (svc *SantaService) UploadEvent(ctx context.Context, machineID string, even
 			return errors.Wrap(err, "marshal event info to json")
 		}
 
+		eventInfoJSON = append(eventInfoJSON, "\n"...)
+
 		if err := os.WriteFile(eventPath, eventInfoJSON, 0644); err != nil {
 			return errors.Wrapf(err, "write event to path %s", eventPath)
 		}


### PR DESCRIPTION
Appends a newline to eventInfoJSON.  This is required by some log handlers such as vector.dev:   https://vector.dev/docs/reference/configuration/sources/file