### PR TITLE
log preflight events

### DIFF
--- a/moroz/svc_preflight.go
+++ b/moroz/svc_preflight.go
@@ -66,6 +66,7 @@ func (mw logmw) Preflight(ctx context.Context, machineID string, p santa.Preflig
 		_ = mw.logger.Log(
 			"method", "Preflight",
 			"machine_id", machineID,
+			"preflight_payload", p,
 			"err", err,
 			"took", time.Since(begin),
 		)

--- a/santa/santa.go
+++ b/santa/santa.go
@@ -37,15 +37,20 @@ type Preflight struct {
 
 // A PreflightPayload represents the request sent by a santa client to the sync server.
 type PreflightPayload struct {
-	OSBuild              string     `json:"os_build"`
-	SantaVersion         string     `json:"santa_version"`
+	SerialNumber         string     `json:"serial_num"`
 	Hostname             string     `json:"hostname"`
 	OSVersion            string     `json:"os_version"`
-	CertificateRuleCount int        `json:"certificate_rule_count"`
-	BinaryRuleCount      int        `json:"binary_rule_count"`
-	ClientMode           ClientMode `json:"client_mode"`
-	SerialNumber         string     `json:"serial_num"`
+	OSBuild              string     `json:"os_build"`
+	ModelIdentifier      string     `json:"model_identifier"`
+	SantaVersion         string     `json:"santa_version"`
 	PrimaryUser          string     `json:"primary_user"`
+	BinaryRuleCount      int        `json:"binary_rule_count"`
+	CertificateRuleCount int        `json:"certificate_rule_count"`
+	CompilerRuleCount    int        `json:"compiler_rule_count"`
+	TransitiveRuleCount  int        `json:"transitive_rule_count"`
+	TeamIDRuleCount      int        `json:"teamid_rule_count"`
+	ClientMode           ClientMode `json:"client_mode"`
+	RequestCleanSync     bool       `json:"request_clean_sync"`
 }
 
 // EventPayload represents derived metadata for events uploaded with the UploadEvent endpoint.


### PR DESCRIPTION
Adding preflight logging to moroz. This isn't fully up-to-date based on https://github.com/google/santa/pull/1275 but that will have to come later. 

Local server logs:
```
❯ ./build/darwin/moroz -configs ./configs/global.toml -http-addr=:3000 -use-tls=false -debug
{"addr":":3000","caller":"main.go:109","msg":"serve http","severity":"debug","tls":false,"ts":"2024-02-01T14:31:03.401763Z"}
{"caller":"svc_preflight.go:76","err":null,"machine_id":"some-machine-id","method":"Preflight","preflight_payload":{"serial_num":"0123456789","hostname":"st-somehostname","os_version":"14.2.1","os_build":"23C71","model_identifier":"MacBookPro18,2","santa_version":"2023.9.579822660","primary_user":"someusername","binary_rule_count":243,"certificate_rule_count":619,"compiler_rule_count":1,"transitive_rule_count":0,"teamid_rule_count":18,"client_mode":"LOCKDOWN","request_clean_sync":true},"severity":"info","took":"490.5µs","ts":"2024-02-01T14:32:01.718255Z"}
```

