### PR TITLE
Added ability to disable writing events to disk with -persist-events flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Usage of moroz:
     	path to config folder (default "../../configs")
   -event-logfile string
     	path to file for saving uploaded events (default "/tmp/santa_events")
+  -persist-events
+      Enable writing events to disk (default `true`)
   -http-addr string
     	http address ex: -http-addr=:8080 (default ":8080")
   -tls-cert string

--- a/cmd/moroz/main.go
+++ b/cmd/moroz/main.go
@@ -42,14 +42,15 @@ The latest version of santa is available on the github repo page:
 
 func main() {
 	var (
-		flTLSCert = flag.String("tls-cert", env.String("MOROZ_TLS_CERT", "server.crt"), "path to TLS certificate")
-		flTLSKey  = flag.String("tls-key", env.String("MOROZ_TLS_KEY", "server.key"), "path to TLS private key")
-		flAddr    = flag.String("http-addr", env.String("MOROZ_HTTP_ADDRESS", ":8080"), "http address ex: -http-addr=:8080")
-		flConfigs = flag.String("configs", env.String("MOROZ_CONFIGS", "../../configs"), "path to config folder")
-		flEvents  = flag.String("event-dir", env.String("MOROZ_EVENT_DIR", "/tmp/santa_events"), "Path to root directory where events will be stored.")
-		flVersion = flag.Bool("version", false, "print version information")
-		flDebug   = flag.Bool("debug", false, "log at a debug level by default.")
-		flUseTLS  = flag.Bool("use-tls", true, "I promise I terminated TLS elsewhere when changing this")
+		flTLSCert       = flag.String("tls-cert", env.String("MOROZ_TLS_CERT", "server.crt"), "path to TLS certificate")
+		flTLSKey        = flag.String("tls-key", env.String("MOROZ_TLS_KEY", "server.key"), "path to TLS private key")
+		flAddr          = flag.String("http-addr", env.String("MOROZ_HTTP_ADDRESS", ":8080"), "http address ex: -http-addr=:8080")
+		flConfigs       = flag.String("configs", env.String("MOROZ_CONFIGS", "../../configs"), "path to config folder")
+		flEvents        = flag.String("event-dir", env.String("MOROZ_EVENT_DIR", "/tmp/santa_events"), "Path to root directory where events will be stored.")
+		flPersistEvents = flag.Bool("persist-events", env.Bool("MOROZ_WRITE_EVENTS", true), "Enable or disable event persistence to disk. Defaults to enabled.")
+		flVersion       = flag.Bool("version", false, "print version information")
+		flDebug         = flag.Bool("debug", false, "log at a debug level by default.")
+		flUseTLS        = flag.Bool("use-tls", true, "I promise I terminated TLS elsewhere when changing this")
 	)
 	flag.Parse()
 
@@ -73,7 +74,7 @@ func main() {
 	repo := santaconfig.NewFileRepo(*flConfigs)
 	var svc moroz.Service
 	{
-		s, err := moroz.NewService(repo, *flEvents)
+		s, err := moroz.NewService(repo, *flEvents, *flPersistEvents)
 		if err != nil {
 			logutil.Fatal(logger, err)
 		}

--- a/moroz/service.go
+++ b/moroz/service.go
@@ -14,12 +14,13 @@ type ConfigStore interface {
 }
 
 type SantaService struct {
-	global   santa.Config
-	repo     ConfigStore
-	eventDir string
+	global          santa.Config
+	repo            ConfigStore
+	eventDir        string
+	flPersistEvents bool
 }
 
-func NewService(ds ConfigStore, eventDir string) (*SantaService, error) {
+func NewService(ds ConfigStore, eventDir string, flPersistEvents bool) (*SantaService, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	global, err := ds.Config(ctx, "global")
@@ -27,9 +28,10 @@ func NewService(ds ConfigStore, eventDir string) (*SantaService, error) {
 		return nil, err
 	}
 	return &SantaService{
-		global:   global,
-		repo:     ds,
-		eventDir: eventDir,
+		global:          global,
+		repo:            ds,
+		eventDir:        eventDir,
+		flPersistEvents: flPersistEvents,
 	}, nil
 }
 

--- a/moroz/svc_upload_event.go
+++ b/moroz/svc_upload_event.go
@@ -17,6 +17,9 @@ import (
 )
 
 func (svc *SantaService) UploadEvent(ctx context.Context, machineID string, events []santa.EventPayload) error {
+	if !svc.flPersistEvents {
+		return nil
+	}
 	for _, ev := range events {
 		eventDir := filepath.Join(svc.eventDir, ev.FileSHA, machineID)
 		if err := os.MkdirAll(eventDir, 0700); err != nil {


### PR DESCRIPTION
Description:
This pull request introduces a flag, -persist-events, to moroz to addresses the issue of high directory creation and possible inode shortage in some cases along with increased memory usage.

Changes:
Added flPersistEvents field to SantaService struct in moroz/service.go.
Updated all references to SantaService to include the new flPersistEvents field.
Modified related functions and methods to accommodate the new flPersistEvents field.

Impact:
This change allows us to control whether events should be persisted, providing more flexibility for the user. The default value is set to true.

Testing:
Tested locally and successfully stopped writing to disk by when set to false. 
./moroz -configs="./configs" -event-dir="./logs" -persist-events="false"