### PR TITLE
Updated README.md to reflect `sha256` deprecation in favor of `identi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ batch_size = 100
 [[rules]]
 rule_type = "BINARY"
 policy = "BLOCKLIST"
-sha256 = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
+identifier = "2dc104631939b4bdf5d6bccab76e166e37fe5e1605340cf68dab919df58b8eda"
 custom_msg = "blocklist firefox"
 
 [[rules]]
 rule_type = "CERTIFICATE"
 policy = "BLOCKLIST"
-sha256 = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
+identifier = "e7726cf87cba9e25139465df5bd1557c8a8feed5c7dd338342d8da0959b63c8d"
 custom_msg = "blocklist dash app certificate"
 
 [[rules]]


### PR DESCRIPTION
I configured **moroz** with a binary rule following the current examples in `README.md`. I pasted the sha256 from the block event into my config:
```
[[rules]]
rule_type = "BINARY"
policy = "ALLOWLIST"
sha256 = "<snip>"
```

I received an error on a Santa client after running `santactl sync`:
```
Ignoring bad rule: policy: ALLOWLIST
rule_type: BINARY

received 100 rules
processed 99 rules
```

After digging into why `sha256` wasn't working and was actively rejected by Santa clients, I found this line of code in Santa project that deprecates `sha256` in favor of the term `identifier`:

https://github.com/google/santa/blob/261425aa64bd49523ef99845dab04797da4fa614/Source/santasyncservice/syncv1.proto#L293

Using `identifier` instead fixed my issue. This change updates `README.md` to save others from having to track this down too.