### PR TITLE
Add Subject Alt Name to certificate creation script

### DIFF
--- a/tools/dev/certificate/create
+++ b/tools/dev/certificate/create
@@ -2,6 +2,6 @@
 
 openssl genrsa -out server.key 2048
 openssl rsa -in server.key -out server.key
-openssl req -sha256 -new -key server.key -out server.csr -subj "/CN=santa"
-openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
+openssl req -sha256 -new -key server.key -out server.csr -subj "/CN=santa" -addext "subjectAltName=DNS:santa"
+openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt -extensions v3_req -extfile <(printf "[v3_req]\nsubjectAltName=DNS:santa")
 rm -f server.csr


### PR DESCRIPTION
I was seeing Santa sync errors like this when I deployed moroz locally and used the certificate tools to generate and trust a local TLS certificate:
```
% sudo santactl sync --debug
Missing Machine Owner.
Preflight starting
Performing request, attempt 1 (of 5 maximum)...
Server Trust: /O=(null)/OU=(null)/CN=santa/SHA-1=d4487ce47b2a8ddca9d8c12296ce0e4feea37418
Server Trust: Unable to evaluate certificate chain for server: A host name mismatch has occurred. (-67602)
Unable to verify server identity.
Performing request, attempt 2 (of 5 maximum)...
Server Trust: /O=(null)/OU=(null)/CN=santa/SHA-1=d4487ce47b2a8ddca9d8c12296ce0e4feea37418
Server Trust: Unable to evaluate certificate chain for server: A host name mismatch has occurred. (-67602)
Unable to verify server identity.
```

What I found is that the system libraries Santa is using expects there to be a Subject or Subject Alt Name in the certificate in order to connect.

This change adds the SAN to the self-signed certificate the creation script outputs.